### PR TITLE
README: update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ lto = "fat"
 There are examples of simple commit-and-prove SNARKs in the `examples` directory. For example, you may run
 
 ```bash
-cargo run --release --example sha256_circuit
+cargo run --release --example keccak
 ```
 
 By default, all the examples are run on relatively small instance sizes. The examples accept command line arguments to specify the size of the data.


### PR DESCRIPTION
sha256_circuit does not seem to exist anymore. `keccak` does.